### PR TITLE
Updated Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 build: go-get install test
 
 go-get:
-	go get golang.org/x/tools/cmd/vet
 	go get github.com/golang/lint/golint
 	go get golang.org/x/tools/cmd/goimports
 	go get github.com/trustmaster/goflow


### PR DESCRIPTION
Since vet is now included in go, this is no longer required and only causes a crash.